### PR TITLE
Default script descriptions

### DIFF
--- a/lib/default-info.js
+++ b/lib/default-info.js
@@ -1,0 +1,8 @@
+module.exports = {
+  info: 'Display information about the scripts',
+  start: 'Kickstart the application',
+  test: 'Run the tests',
+  build: 'Build the package',
+  watch: 'Watch codebase, trigger build when source code changes',
+  cover: 'Execute test coverage',
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,26 @@
 var pkg = require('./pkg');
+var defaultInfo = require('./default-info');
 
 function info() {
-  var scripts = pkg()['scripts-info'];
+  var pkgJSON = pkg();
+  var scriptsInfo = pkgJSON['scripts-info'] || {};
 
-  if ( !scripts ) {
-    throw new Error('Oops, but no `scripts-info` property was found in your `package.json`');
+  Object.keys(pkgJSON.scripts || {})
+    .filter(function(scriptName) {
+      return !(scriptName in scriptsInfo);
+    })
+    .filter(function(scriptName) {
+      return scriptName in defaultInfo;
+    })
+    .map(function(scriptName) {
+      scriptsInfo[scriptName] = defaultInfo[scriptName];
+    });
+
+  if ( !Object.keys(scriptsInfo).length ) {
+    throw new Error("Oops, there's no info about your scripts. Consider fleshing out the `scripts-info` property in your `package.json`");
   }
 
-  return scripts;
+  return scriptsInfo;
 }
 
 module.exports = info;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,19 +1,23 @@
 var pkg = require('./pkg');
-var defaultInfo = require('./default-info');
+var defaults = require('./default-info');
 
 function info() {
   var pkgJSON = pkg();
   var scriptsInfo = pkgJSON['scripts-info'] || {};
 
-  Object.keys(pkgJSON.scripts || {})
+  if ( !pkgJSON.scripts || !Object.keys(pkgJSON.scripts).length ) {
+    throw new Error("Your `package.json` doesn't have npm scripts");
+  }
+
+  Object.keys(pkgJSON.scripts)
     .filter(function(scriptName) {
       return !(scriptName in scriptsInfo);
     })
     .filter(function(scriptName) {
-      return scriptName in defaultInfo;
+      return scriptName in defaults;
     })
     .map(function(scriptName) {
-      scriptsInfo[scriptName] = defaultInfo[scriptName];
+      scriptsInfo[scriptName] = defaults[scriptName];
     });
 
   if ( !Object.keys(scriptsInfo).length ) {

--- a/readme.md
+++ b/readme.md
@@ -32,5 +32,16 @@ You can check the [default reporter](lib/reporter.js) to get the gist of how it 
 
 **Note**: If you're publishing your own reporter, please prefix it with `npm-scripts-info` (e.g., `npm-scripts-info-my-reporter`) for searchability.
 
+## Default Descriptions
+
+Some of the npm scripts are standardized. `npm-scripts-info` provides default descriptions for them, if no custom description specified in `scripts-info`.
+
+* **info** - Display information about the scripts
+* **start** - Kickstart the application
+* **test** - Run the tests
+* **build** - Build the package
+* **watch** - Watch codebase, trigger build when source code changes
+* **cover** - Execute test coverage
+
 ## Preview
 ![preview](preview.png)

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -4,14 +4,63 @@ var rewire = require('rewire');
 var info = rewire('../lib');
 
 describe('npm-script-info', function() {
-  it('should extract `scripts-info` from package.json', function() {
-    var dummy = {};
+  var revert;
+  var pkgJSON;
 
-    var revert = info.__set__('pkg', function() {
-      return { 'scripts-info': dummy };
+  before(function() {
+    revert = info.__set__('pkg', function() {
+      return pkgJSON;
     });
+  });
+
+  after(function() {
+    revert();
+  });
+
+  it('should throw exception if no description found', function() {
+    pkgJSON = {};
+
+    expect(function() {
+      info();
+    }).to.throw(Error, "Oops, there's no info about your scripts. Consider fleshing out the `scripts-info` property in your `package.json`");
+  });
+
+  it('should extract `scripts-info` from package.json', function() {
+    var dummy = {
+      foo: 'bar',
+    };
+
+    pkgJSON = { 'scripts-info': dummy };
 
     expect(info()).to.eql(dummy);
-    revert();
+  });
+
+  it('should add default script info if missing in `scripts-info`', function() {
+    pkgJSON = {
+      scripts: {
+        info: 'npm-scripts-info',
+        start: 'node index',
+      },
+    };
+
+    expect(info()).to.eql({
+      info: 'Display information about the scripts',
+      start: 'Kickstart the application',
+    });
+  });
+
+  it('should not override script info with default description', function() {
+    pkgJSON = {
+      scripts: {
+        start: 'node index',
+      },
+      'scripts-info': {
+        start: 'Custom start description'
+      }
+    };
+
+    expect(info()).to.eql({
+      start: 'Custom start description',
+    });
   });
 });

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -17,8 +17,30 @@ describe('npm-script-info', function() {
     revert();
   });
 
-  it('should throw exception if no description found', function() {
+  it('should throw exception if there is no scripts property in `package.json`', function() {
     pkgJSON = {};
+
+    expect(function() {
+      info();
+    }).to.throw(Error, "Your `package.json` doesn't have npm scripts");
+  });
+
+  it('should throw exception if there are no scripts in the scripts property', function() {
+    pkgJSON = {
+      scripts: {},
+    };
+
+    expect(function() {
+      info();
+    }).to.throw(Error, "Your `package.json` doesn't have npm scripts");
+  });
+
+  it('should throw exception if no description found', function() {
+    pkgJSON = {
+      scripts: {
+        'not documented script': '',
+      },
+    };
 
     expect(function() {
       info();
@@ -30,7 +52,12 @@ describe('npm-script-info', function() {
       foo: 'bar',
     };
 
-    pkgJSON = { 'scripts-info': dummy };
+    pkgJSON = {
+      scripts: {
+        'not documented script': '',
+      },
+      'scripts-info': dummy,
+    };
 
     expect(info()).to.eql(dummy);
   });


### PR DESCRIPTION
This is a great module! I suggest to add standard descriptions (that can be overriden) for some of the npm scripts.

I think in the future this module can even be a place where the npm scripts can finally be standardized. This can be the first step in that direction.

**From the readme:** Some of the npm scripts are standardized. `npm-scripts-info` provides default descriptions for them, if no custom description specified in `scripts-info`.
- **info** - Display information about the scripts
- **start** - Kickstart the application
- **test** - Run the tests
- **build** - Build the package
- **watch** - Watch codebase, trigger build when source code changes
- **cover** - Execute test coverage
