### PR TITLE
Store descriptions in the scripts property

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 var pkg = require('./pkg');
 var defaults = require('./default-info');
+var unquote = require('unquote');
 
 function info() {
   var pkgJSON = pkg();
@@ -34,33 +35,26 @@ function getScriptsInfo(pkgJSON) {
 
   var scriptsInfo = {};
   Object.keys(pkgJSON.scripts || {})
-    .filter(scriptIsDescription)
+    .filter(isDescription)
     .forEach(function(scriptName) {
-      scriptsInfo[scriptName.substr(1)] = getScriptDecription(pkgJSON.scripts[scriptName]);
+      scriptsInfo[scriptName.substr(1)] = getDescription(pkgJSON.scripts[scriptName]);
     });
 
   return scriptsInfo;
 }
 
-function scriptIsDescription(scriptName) {
+function isDescription(scriptName) {
   return scriptName[0] === '?';
 }
 
-function getScriptDecription(description) {
+function getDescription(description) {
   if (description.indexOf('echo ') !== 0) {
     return description;
   }
 
-  var woEchoDescription = description.replace('echo ', '');
+  var woEchoDescription = description.replace(/^echo\s+/, '');
 
-  return removeQuotes('"', removeQuotes("'", woEchoDescription));
-}
-
-function removeQuotes(quoteChar, text) {
-  if (text[0] === quoteChar && text[text.length - 1] === quoteChar) {
-    return text.substr(1, text.length - 2);
-  }
-  return text;
+  return unquote(woEchoDescription);
 }
 
 module.exports = info;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ var defaults = require('./default-info');
 
 function info() {
   var pkgJSON = pkg();
-  var scriptsInfo = pkgJSON['scripts-info'] || {};
+  var scriptsInfo = getScriptsInfo(pkgJSON);
 
   if ( !pkgJSON.scripts || !Object.keys(pkgJSON.scripts).length ) {
     throw new Error("Your `package.json` doesn't have npm scripts");
@@ -25,6 +25,42 @@ function info() {
   }
 
   return scriptsInfo;
+}
+
+function getScriptsInfo(pkgJSON) {
+  if ('scripts-info' in pkgJSON) {
+    return pkgJSON['scripts-info'];
+  }
+
+  var scriptsInfo = {};
+  Object.keys(pkgJSON.scripts || {})
+    .filter(scriptIsDescription)
+    .forEach(function(scriptName) {
+      scriptsInfo[scriptName.substr(1)] = getScriptDecription(pkgJSON.scripts[scriptName]);
+    });
+
+  return scriptsInfo;
+}
+
+function scriptIsDescription(scriptName) {
+  return scriptName[0] === '?';
+}
+
+function getScriptDecription(description) {
+  if (description.indexOf('echo ') !== 0) {
+    return description;
+  }
+
+  var woEchoDescription = description.replace('echo ', '');
+
+  return removeQuotes('"', removeQuotes("'", woEchoDescription));
+}
+
+function removeQuotes(quoteChar, text) {
+  if (text[0] === quoteChar && text[text.length - 1] === quoteChar) {
+    return text.substr(1, text.length - 2);
+  }
+  return text;
 }
 
 module.exports = info;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "meow": "^3.7.0"
+    "meow": "^3.7.0",
+    "unquote": "^1.1.0"
   },
   "repository": "srph/npm-scripts-info"
 }

--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,10 @@ npm i -S npm-scripts-info
 ```
 
 ## Usage
+
+### Using the `scripts-info` property
 Add the descriptions (`scripts-info`) to your `package.json`. Afterwards, add `npm-scripts-info` to your scripts.
-```js
+```json
 {
   "name": "my-project",
   "scripts": {
@@ -22,6 +24,30 @@ Add the descriptions (`scripts-info`) to your `package.json`. Afterwards, add `n
 }
 ```
 Finally, run `npm run info`.
+
+### Usings scripts prefixed with `?`
+
+For modules with dozens of scripts it might be a better option to store the descriptions near the commands. `npm-scripts-info` allows to store the scripts descriptions in the `scripts` property. In order to add a script description, just prefix its name with `?`.
+
+```json
+{
+  "name": "my-project",
+  "scripts": {
+    "?info": "Display information about the scripts.",
+    "info": "npm-scripts-info",
+
+    "?watch:build": "Watch codebase, trigger build when source code changes",
+    "watch:build": "webpack --watch",
+
+    "?start": "echo Kickstarts the application.",
+    "start": "node index"
+  }
+}
+```
+
+Have you noticed the `echo` command in the `start` description? Hence the descriptions are inside the script property, they can be called using `npm run`. By adding the `echo` command to the description properties you can make valid scripts from them. Therefore, running `npm run ?start` will print the description of the `start` script. And the great thing is, `npm-scripts-info` is smart enough to fetch the description from the `echo` command!
+
+**NOTE:** The prefixed commands will be looked up for descriptions only if the `package.json` doesn't have a `scripts-info` property.
 
 ## Custom Reporters
 You can customize the output by specifying a reporter.

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -90,4 +90,56 @@ describe('npm-script-info', function() {
       start: 'Custom start description',
     });
   });
+
+  it('should get script info from scripts property', function() {
+    pkgJSON = {
+      scripts: {
+        '?start': 'Custom start description',
+        start: 'node index',
+      },
+    };
+
+    expect(info()).to.eql({
+      start: 'Custom start description',
+    });
+  });
+
+  it('should remove `echo` from script description', function() {
+    pkgJSON = {
+      scripts: {
+        '?start': 'echo Custom start description',
+        start: 'node index',
+      },
+    };
+
+    expect(info()).to.eql({
+      start: 'Custom start description',
+    });
+  });
+
+  it('should remove `echo` and double quotes from script description', function() {
+    pkgJSON = {
+      scripts: {
+        '?start': 'echo "Custom start description"',
+        start: 'node index',
+      },
+    };
+
+    expect(info()).to.eql({
+      start: 'Custom start description',
+    });
+  });
+
+  it('should remove `echo` and single quotes from script description', function() {
+    pkgJSON = {
+      scripts: {
+        '?start': "echo 'Custom start description'",
+        start: 'node index',
+      },
+    };
+
+    expect(info()).to.eql({
+      start: 'Custom start description',
+    });
+  });
 });


### PR DESCRIPTION
Add the possibility to store the descriptions not only in the `scripts-info` property but in the `scripts` property as well. Properties that are prefixed with ? in the `scripts` are descriptions for the corresponding scripts.

closes #6 
