### PR TITLE
Strip flags from echo command

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,13 +48,19 @@ function isDescription(scriptName) {
 }
 
 function getDescription(description) {
-  if (description.indexOf('echo ') !== 0) {
+  var rex = /^\s*echo\s+/;
+  var match = rex.exec(description);
+  if (match === null) {
     return description;
   }
 
-  var woEchoDescription = description.replace(/^echo\s+/, '');
+  description = description.substr(match[0].length);
+  rex = /^-[eEn]+\s+/;
+  while ((match = rex.exec(description)) !== null) {
+    description = description.substr(match[0].length);
+  }
 
-  return unquote(woEchoDescription);
+  return unquote(description);
 }
 
 module.exports = info;

--- a/package.json
+++ b/package.json
@@ -13,17 +13,17 @@
   "author": "Kier Borromeo <seraphipod@gmail.com> (http://srph.github.io)",
   "license": "ISC",
   "devDependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^2.4.5",
-    "mock-fs": "^3.7.0",
-    "mos": "^0.15.0",
-    "read-pkg-up": "^1.0.1",
-    "rewire": "^2.5.1",
-    "sinon": "^1.17.3"
+    "chai": "^4.1.2",
+    "mocha": "^5.0.0",
+    "mock-fs": "^4.4.2",
+    "mos": "^1.3.1",
+    "read-pkg-up": "^3.0.0",
+    "rewire": "^3.0.2",
+    "sinon": "^4.2.2"
   },
   "dependencies": {
-    "chalk": "^1.1.1",
-    "meow": "^3.7.0",
+    "chalk": "^2.3.0",
+    "meow": "^4.0.0",
     "unquote": "^1.1.0"
   },
   "repository": "srph/npm-scripts-info"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "info": "node lib/cli",
-    "test": "mocha tests && mos test",
-    "md": "mos",
-    "?md": "echo \"Update the markdown files\""
+    "test": "mocha tests"
   },
   "bin": "./lib/cli.js",
   "author": "Kier Borromeo <seraphipod@gmail.com> (http://srph.github.io)",
@@ -16,7 +14,6 @@
     "chai": "^4.1.2",
     "mocha": "^5.0.0",
     "mock-fs": "^4.4.2",
-    "mos": "^1.3.1",
     "read-pkg-up": "^3.0.0",
     "rewire": "^3.0.2",
     "sinon": "^4.2.2"

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,7 @@
-<!--@ '# ' + package.name + ' ' + shields.flatSquare('npm', 'travis') -->
 # npm-scripts-info [![NPM version](https://img.shields.io/npm/v/npm-scripts-info.svg?style=flat-square)](https://www.npmjs.com/package/npm-scripts-info) [![Build status for master](https://img.shields.io/travis/srph/npm-scripts-info/master.svg?style=flat-square)](https://travis-ci.org/srph/npm-scripts-info)
-<!--/@-->
 
-<!--@package.description-->
 Display the description of your npm scripts.
-<!--/@-->
 
-<!--@installation()-->
 ## Installation
 
 This module is installed via npm:
@@ -14,7 +9,6 @@ This module is installed via npm:
 ```sh
 npm install npm-scripts-info --save
 ```
-<!--/@-->
 
 ## Usage
 
@@ -78,7 +72,6 @@ You can check the [default reporter](lib/reporter.js) to get the gist of how it 
 
 You can fetch the scripts descriptions from a `package.json` in JavaScript.
 
-<!--@example('example.js')-->
 ```js
 'use strict';
 var getScriptsInfo = require('npm-scripts-info');
@@ -93,7 +86,6 @@ readPkgUp()
      //    test: 'Run the tests' }
   });
 ```
-<!--/@-->
 
 ## Default Descriptions
 
@@ -110,22 +102,16 @@ Some of the npm scripts are standardized. `npm-scripts-info` provides default de
 
 ![preview](preview.png)
 
-<!--@license()-->
 ## License
 
 ISC © [Kier Borromeo](http://srph.github.io)
-<!--/@-->
 
-<!--@dependencies({ shield: 'flat-square' })-->
 ## <a name="dependencies">Dependencies</a> [![Dependency status for master](https://img.shields.io/david/srph/npm-scripts-info/master.svg?style=flat-square)](https://david-dm.org/srph/npm-scripts-info/master)
 
 - [chalk](https://github.com/chalk/chalk): Terminal string styling done right. Much color.
 - [meow](https://github.com/sindresorhus/meow): CLI app helper
 - [unquote](https://github.com/lakenen/node-unquote): Remove wrapping quotes from a string.
 
-<!--/@-->
-
-<!--@devDependencies({ shield: 'flat-square' })-->
 ## <a name="dev-dependencies">Dev Dependencies</a> [![devDependency status for master](https://img.shields.io/david/dev/srph/npm-scripts-info/master.svg?style=flat-square)](https://david-dm.org/srph/npm-scripts-info/master#info=devDependencies)
 
 - [chai](https://github.com/chaijs/chai): BDD/TDD assertion library for node.js and the browser. Test framework agnostic.
@@ -135,5 +121,3 @@ ISC © [Kier Borromeo](http://srph.github.io)
 - [read-pkg-up](https://github.com/sindresorhus/read-pkg-up): Read the closest package.json file
 - [rewire](https://github.com/jhnns/rewire): Easy dependency injection for node.js unit testing
 - [sinon](https://github.com/cjohansen/Sinon.JS): JavaScript test spies, stubs and mocks.
-
-<!--/@-->

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -143,6 +143,34 @@ describe('npm-script-info', function() {
     });
   });
 
+  it('should remove known `echo` flags from script description', function() {
+    pkgJSON = {
+      scripts: {
+        '?start1': "echo -e Custom start description",
+        start1: 'node index',
+        '?start2': "echo -n Custom start description",
+        start2: 'node index',
+        '?start3': "echo -e -n Custom start description",
+        start3: 'node index',
+        '?start4': "echo -en Custom start description",
+        start4: 'node index',
+        '?start5': "echo -en -x Custom start description",
+        start5: 'node index',
+        '?start6': "echo -enCustom start description",
+        start6: 'node index',
+      },
+    };
+
+    expect(info()).to.eql({
+      start1: 'Custom start description',
+      start2: 'Custom start description',
+      start3: 'Custom start description',
+      start4: 'Custom start description',
+      start5: '-x Custom start description',
+      start6: '-enCustom start description',
+    });
+  });
+
   it('should use the passed in package.json instead of the one in the cwd', function() {
     pkgJSON = {
       scripts: {


### PR DESCRIPTION
Hi, thanks for this nice package!

I just noticed that it doesn't strip flags, like `'-n'`, that I might have on my echo commands, so I thought I would submit a PR to include that. I hope that makes sense.

I also noticed some of the dependencies were outdated, and found out that upgrading them was almost painless.

The only problem was that the `mos` devDependency seems to be not working after upgrade, so for the moment I thought it might be allright to remove it.